### PR TITLE
Add support for ADX audio and 8-bit stereo PCM

### DIFF
--- a/src/bin/cinerepak.rs
+++ b/src/bin/cinerepak.rs
@@ -126,15 +126,24 @@ fn main() {
         // To accommodate that, we need to separate the audio data into left/right
         // segments here so that they can be reformatted into planar chunks as
         // necessary.
-        left_vec = input_audio_data.chunks(4)
-                                           .flat_map(|bytes| vec![bytes[0], bytes[1]])
+
+        // A pair of 16-bit samples is 4 bytes (2 bytes per sample)
+        let chunk_size;
+        if header.fdsc.audio_resolution == 16 {
+            chunk_size = 4;
+        } else {
+            chunk_size = 2;
+        }
+
+        left_vec = input_audio_data.chunks(chunk_size)
+                                           .flat_map(|bytes| bytes[0..chunk_size / 2].to_vec())
                                            .collect::<Vec<u8>>();
         left_cursor = io::Cursor::new(left_vec);
-        right_vec = input_audio_data.chunks(4)
-                                            .flat_map(|bytes| vec![bytes[2], bytes[3]])
+        right_vec = input_audio_data.chunks(chunk_size)
+                                            .flat_map(|bytes| bytes[chunk_size / 2..chunk_size].to_vec())
                                             .collect::<Vec<u8>>();
         right_cursor = io::Cursor::new(right_vec);
-    // TODO this will support ADX, but not 8-bit stereo PCM (like Magical School Lunar)
+    // Pass through audio unaltered.
     } else {
         left_vec = input_audio_data;
         left_cursor = io::Cursor::new(left_vec);

--- a/src/bin/cinerepak.rs
+++ b/src/bin/cinerepak.rs
@@ -137,12 +137,12 @@ fn main() {
         }
 
         let left_vec = input_audio_data.chunks(chunk_size)
-                                           .flat_map(|bytes| bytes[0..chunk_size / 2].to_vec())
-                                           .collect::<Vec<u8>>();
+                                        .flat_map(|bytes| bytes[0..chunk_size / 2].to_vec())
+                                        .collect::<Vec<u8>>();
         let left_cursor = io::Cursor::new(left_vec);
         let right_vec = input_audio_data.chunks(chunk_size)
-                                            .flat_map(|bytes| bytes[chunk_size / 2..chunk_size].to_vec())
-                                            .collect::<Vec<u8>>();
+                                        .flat_map(|bytes| bytes[chunk_size / 2..chunk_size].to_vec())
+                                        .collect::<Vec<u8>>();
         let right_cursor = io::Cursor::new(right_vec);
 
         data = AudioData {


### PR DESCRIPTION
Previously the assumption that all audio was 16-bit stereo was baked in, which meant that all other audio got reformatted as though it were in that format. This mangled ADX, mono PCM, and 8-bit stereo PCM in different ways from each other. This now handles different bit depths and allows passing through formats like ADX unaltered.